### PR TITLE
feat: add Prettier as default formatter and enable final newline in VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,8 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
   "files.eol": "\n",
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "files.insertFinalNewline": true,
   "github.copilot.chat.commitMessageGeneration.instructions": [
     {
       "file": "node_modules/@map-colonies/infra-copilot-instructions/instructions/commit.md"


### PR DESCRIPTION
This pull request includes updates to the Visual Studio Code settings to improve code formatting consistency.

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L3-R5): Added `editor.defaultFormatter` to use `esbenp.prettier-vscode` and set `files.insertFinalNewline` to true.