### PR TITLE
feat: Add endpoint to update stage status and implement state machine

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -496,50 +496,52 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/errorMessage'
-  # /stages/{stageId}/status:
-  # put:
-  #   operationId: changeStageStatus
-  #   parameters:
-  #     - $ref: '#/components/parameters/stageId'
-  #   summary: change stage's status
-  #   tags:
-  #     - stages
-  #   requestBody:
-  #     required: true
-  #     content:
-  #       application/json:
-  #         schema:
-  #           type: object
-  #           properties:
-  #             status:
-  #               $ref: '#/components/schemas/stageOperationStatus'
-  #   responses:
-  #     '200':
-  #       description: Stage and tasks will move to wait status
-  #       content:
-  #         application/json:
-  #           schema:
-  #             $ref: '#/components/schemas/defaultOkMessage'
-  #           example:
-  #             code: STATUS_MODIFIED_SUCCESSFULLY
-  #     '400':
-  #       description: Bad parameters input
-  #       content:
-  #         application/json:
-  #           schema:
-  #             $ref: '#/components/schemas/errorMessage'
-  #     '404':
-  #       description: No such stage on database
-  #       content:
-  #         application/json:
-  #           schema:
-  #             $ref: '#/components/schemas/errorMessage'
-  #     '500':
-  #       description: Internal server error
-  #       content:
-  #         application/json:
-  #           schema:
-  #             $ref: '#/components/schemas/errorMessage'
+  /stages/{stageId}/status:
+    put:
+      operationId: updateStageStatus
+      parameters:
+        - $ref: '#/components/parameters/stageId'
+      summary: change stage's status
+      tags:
+        - stages
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  $ref: '#/components/schemas/stageOperationStatus'
+              required:
+                - status
+      responses:
+        '200':
+          description: Stage and tasks will move to wait status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/defaultOkMessage'
+              example:
+                code: JOB_MODIFIED_SUCCESSFULLY
+        '400':
+          description: Bad parameters input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorMessage'
+        '404':
+          description: No such stage on database
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorMessage'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorMessage'
 security: []
 
 components:
@@ -730,7 +732,6 @@ components:
         - STAGE_MODIFIED_SUCCESSFULLY
         - JOB_DELETED_SUCCESSFULLY
         # - JOB_RESTARTED_SUCCESSFULLY
-        # - STATUS_MODIFIED_SUCCESSFULLY
         # - USER_METADATA_MODIFIED_SUCCESSFULLY
         # - TASKS_ADDED_SUCCESSFULLY
         # - TASK_FAILED_SUCCESSFULLY

--- a/src/openapi.d.ts
+++ b/src/openapi.d.ts
@@ -186,6 +186,23 @@ export type paths = {
     patch: operations['updateStageUserMetadata'];
     trace?: never;
   };
+  '/stages/{stageId}/status': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /** change stage's status */
+    put: operations['updateStageStatus'];
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 };
 export type webhooks = Record<string, never>;
 export type components = {
@@ -1019,6 +1036,62 @@ export interface operations {
     };
     responses: {
       /** @description modify user metadata object */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['defaultOkMessage'];
+        };
+      };
+      /** @description Bad parameters input */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['errorMessage'];
+        };
+      };
+      /** @description No such stage on database */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['errorMessage'];
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['errorMessage'];
+        };
+      };
+    };
+  };
+  updateStageStatus: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description ID of Stage */
+        stageId: components['parameters']['stageId'];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': {
+          status: components['schemas']['stageOperationStatus'];
+        };
+      };
+    };
+    responses: {
+      /** @description Stage and tasks will move to wait status */
       200: {
         headers: {
           [name: string]: unknown;

--- a/src/stages/controllers/stageController.ts
+++ b/src/stages/controllers/stageController.ts
@@ -96,4 +96,21 @@ export class StageController {
       return next(err);
     }
   };
+
+  public updateStatus: TypedRequestHandlers['PUT /stages/{stageId}/status'] = async (req, res, next) => {
+    try {
+      await this.manager.updateStatus(req.params.stageId, req.body.status);
+
+      return res.status(httpStatus.OK).json({ code: successMessages.stageModifiedSuccessfully });
+    } catch (err) {
+      if (err instanceof StageNotFoundError) {
+        (err as HttpError).status = httpStatus.NOT_FOUND;
+      } else if (err instanceof InvalidUpdateError) {
+        (err as HttpError).status = httpStatus.BAD_REQUEST;
+        this.logger.error({ msg: `Stage status update failed: invalid status transition`, status: req.body.status, err });
+      }
+
+      return next(err);
+    }
+  };
 }

--- a/src/stages/models/models.ts
+++ b/src/stages/models/models.ts
@@ -1,4 +1,5 @@
 import type { CamelCase, ScreamingSnakeCase } from 'type-fest';
+import { Prisma } from '@prisma/client';
 import type { components, operations } from '@src/openapi';
 
 type SuccessMessages = components['schemas']['successMessages'];
@@ -16,6 +17,7 @@ type StageModel = components['schemas']['stageResponse'];
 type StageCreateModel = components['schemas']['createStagePayload'];
 type StageSummary = components['schemas']['summary'];
 type StageFindCriteriaArg = operations['getStages']['parameters']['query'];
+type StagePrismaObject = Prisma.StageGetPayload<Prisma.StageDefaultArgs>;
 
 export { successMessages };
-export type { StageSummary, StageModel, StageFindCriteriaArg, StageCreateModel };
+export type { StageSummary, StageModel, StageFindCriteriaArg, StageCreateModel, StagePrismaObject };

--- a/src/stages/models/stageStateMachine.ts
+++ b/src/stages/models/stageStateMachine.ts
@@ -1,0 +1,85 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { setup } from 'xstate';
+import { StageOperationStatus } from '@prisma/client';
+
+type changeStatusOperations = 'pend' | 'wait' | 'pause' | 'abort' | 'complete' | 'process' | 'fail' | 'create';
+
+const OperationStatusMapper: { [key in StageOperationStatus]: changeStatusOperations } = {
+  [StageOperationStatus.PENDING]: 'pend',
+  [StageOperationStatus.IN_PROGRESS]: 'process',
+  [StageOperationStatus.COMPLETED]: 'complete',
+  [StageOperationStatus.FAILED]: 'fail',
+  [StageOperationStatus.ABORTED]: 'abort',
+  [StageOperationStatus.WAITING]: 'wait',
+  [StageOperationStatus.CREATED]: 'create',
+  [StageOperationStatus.PAUSED]: 'pause',
+};
+
+const stageStateMachine = setup({
+  types: {
+    events: {} as
+      | { type: 'pend' }
+      | { type: 'wait' }
+      | { type: 'pause' }
+      | { type: 'abort' }
+      | { type: 'complete' }
+      | { type: 'process' }
+      | { type: 'fail' }
+      | { type: 'create' },
+  },
+}).createMachine({
+  id: 'stageStatus',
+  initial: 'CREATED',
+  states: {
+    CREATED: {
+      on: {
+        pend: { target: 'PENDING' },
+        wait: { target: 'WAITING' },
+        pause: { target: 'PAUSED' },
+        abort: { target: 'ABORTED' },
+      },
+    },
+    PENDING: {
+      on: {
+        wait: { target: 'WAITING' },
+        process: { target: 'IN_PROGRESS' },
+        abort: { target: 'ABORTED' },
+        pause: { target: 'PAUSED' },
+      },
+    },
+    IN_PROGRESS: {
+      on: {
+        complete: { target: 'COMPLETED' },
+        fail: { target: 'FAILED' },
+        abort: { target: 'ABORTED' },
+        pause: { target: 'PAUSED' },
+        wait: { target: 'WAITING' },
+      },
+    },
+    PAUSED: {
+      on: {
+        pend: { target: 'PENDING' },
+        wait: { target: 'WAITING' },
+        process: { target: 'IN_PROGRESS' },
+        abort: { target: 'ABORTED' },
+      },
+    },
+    WAITING: {
+      on: {
+        pend: { target: 'PENDING' },
+        abort: { target: 'ABORTED' },
+      },
+    },
+    COMPLETED: {
+      type: 'final',
+    },
+    FAILED: {
+      type: 'final',
+    },
+    ABORTED: {
+      type: 'final',
+    },
+  },
+});
+
+export { stageStateMachine, OperationStatusMapper };

--- a/src/stages/routes/stageRouter.ts
+++ b/src/stages/routes/stageRouter.ts
@@ -10,6 +10,7 @@ const stageRouterFactory: FactoryFunction<Router> = (dependencyContainer) => {
   router.get('/:stageId', controller.getStageById);
   router.get('/:stageId/summary', controller.getSummaryByStageId);
   router.patch('/:stageId/user-metadata', controller.updateUserMetadata);
+  router.put('/:stageId/status', controller.updateStatus);
 
   return router;
 };

--- a/tests/unit/generator.ts
+++ b/tests/unit/generator.ts
@@ -4,9 +4,11 @@ import { JobOperationStatus, Prisma, Stage, StageOperationStatus } from '@prisma
 import { createActor } from 'xstate';
 import { jobStateMachine } from '@src/jobs/models/jobStateMachine';
 import { JobCreateModel } from '@src/jobs/models/models';
+import { stageStateMachine } from '@src/stages/models/stageStateMachine';
 
-const randomUuid = faker.string.uuid();
+const stageInitializedPersistedSnapshot = createActor(stageStateMachine).start().getPersistedSnapshot();
 
+export const randomUuid = faker.string.uuid();
 export interface JobWithStages extends Prisma.JobGetPayload<Record<string, unknown>> {
   Stage?: Stage[];
 }
@@ -53,11 +55,7 @@ export const createStageEntity = (
     status: StageOperationStatus.CREATED,
     userMetadata: {},
     percentage: 0,
-    xstate: {
-      status: 'active',
-      output: undefined,
-      error: undefined,
-    },
+    xstate: stageInitializedPersistedSnapshot,
   } satisfies Prisma.StageGetPayload<Record<string, never>>;
   return { ...stageEntity, ...override };
 };

--- a/tests/unit/jobs/jobs.spec.ts
+++ b/tests/unit/jobs/jobs.spec.ts
@@ -6,6 +6,7 @@ import { JobManager } from '@src/jobs/models/manager';
 import { errorMessages as jobsErrorMessages } from '@src/jobs/models/errors';
 import { JobCreateModel } from '@src/jobs/models/models';
 import { StageCreateModel } from '@src/stages/models/models';
+import { randomUuid } from '@tests/unit/generator';
 import { jobEntityWithAbortStatus, jobEntityWithEmptyStagesArr, jobEntityWithoutStages, jobEntityWithStages, stageEntity } from '../data';
 
 let jobManager: JobManager;
@@ -198,9 +199,12 @@ describe('JobManager', () => {
     describe('#updateStatus', () => {
       describe('#HappyPath', () => {
         it('should successfully update job status by id', async function () {
-          jest.spyOn(prisma.job, 'findUnique').mockResolvedValue(jobEntityWithoutStages);
+          const jobId = randomUuid;
 
-          await expect(jobManager.updateStatus(jobEntityWithoutStages.id, JobOperationStatus.PENDING)).toResolve();
+          jest.spyOn(prisma.job, 'findUnique').mockResolvedValue({ ...jobEntityWithoutStages, id: jobId });
+          jest.spyOn(prisma.job, 'update').mockResolvedValue(jobEntityWithoutStages);
+
+          await expect(jobManager.updateStatus(jobId, JobOperationStatus.PENDING)).toResolve();
         });
       });
 


### PR DESCRIPTION
Introduce a new endpoint for updating the status of a stage and implement a state machine to manage stage operations. This enhances the functionality for stage status transitions and improves error handling for invalid updates.