### PR TITLE
refactor: remove WAITING status from job operation status enum and related components (MAPCO-7898)

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -1144,7 +1144,6 @@ components:
         - FAILED
         - ABORTED
         - PAUSED
-        - WAITING
         - CREATED
       example: CREATED
       description: |

--- a/src/db/prisma/migrations/20250702083137_remove_aborted_paused_statuses_job/migration.sql
+++ b/src/db/prisma/migrations/20250702083137_remove_aborted_paused_statuses_job/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - The values [Waiting] on the enum `job_operation_status_enum` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "job_operation_status_enum_new" AS ENUM ('Pending', 'In-Progress', 'Completed', 'Failed', 'Aborted', 'Created', 'Paused');
+ALTER TABLE "job" ALTER COLUMN "status" DROP DEFAULT;
+ALTER TABLE "job" ALTER COLUMN "status" TYPE "job_operation_status_enum_new" USING ("status"::text::"job_operation_status_enum_new");
+ALTER TYPE "job_operation_status_enum" RENAME TO "job_operation_status_enum_old";
+ALTER TYPE "job_operation_status_enum_new" RENAME TO "job_operation_status_enum";
+DROP TYPE "job_operation_status_enum_old";
+ALTER TABLE "job" ALTER COLUMN "status" SET DEFAULT 'Created';
+COMMIT;

--- a/src/db/prisma/schema.prisma
+++ b/src/db/prisma/schema.prisma
@@ -37,7 +37,6 @@ enum JobOperationStatus {
   COMPLETED   @map("Completed")
   FAILED      @map("Failed")
   ABORTED     @map("Aborted")
-  WAITING     @map("Waiting")
   CREATED     @map("Created")
   PAUSED      @map("Paused")
 

--- a/src/jobs/models/jobStateMachine.ts
+++ b/src/jobs/models/jobStateMachine.ts
@@ -2,7 +2,7 @@
 import { setup } from 'xstate';
 import { JobOperationStatus } from '@prismaClient';
 
-type ChangeStatusOperations = 'pend' | 'wait' | 'pause' | 'abort' | 'complete' | 'process' | 'fail' | 'create';
+type ChangeStatusOperations = 'pend' | 'pause' | 'abort' | 'complete' | 'process' | 'fail' | 'create';
 
 const OperationStatusMapper: { [key in JobOperationStatus]: ChangeStatusOperations } = {
   [JobOperationStatus.PENDING]: 'pend',
@@ -10,7 +10,6 @@ const OperationStatusMapper: { [key in JobOperationStatus]: ChangeStatusOperatio
   [JobOperationStatus.COMPLETED]: 'complete',
   [JobOperationStatus.FAILED]: 'fail',
   [JobOperationStatus.ABORTED]: 'abort',
-  [JobOperationStatus.WAITING]: 'wait',
   [JobOperationStatus.CREATED]: 'create',
   [JobOperationStatus.PAUSED]: 'pause',
 };
@@ -19,7 +18,6 @@ const jobStateMachine = setup({
   types: {
     events: {} as
       | { type: 'pend' }
-      | { type: 'wait' }
       | { type: 'pause' }
       | { type: 'abort' }
       | { type: 'complete' }
@@ -35,14 +33,12 @@ const jobStateMachine = setup({
     CREATED: {
       on: {
         pend: { target: 'PENDING' },
-        wait: { target: 'WAITING' },
         pause: { target: 'PAUSED' },
         abort: { target: 'ABORTED' },
       },
     },
     PENDING: {
       on: {
-        wait: { target: 'WAITING' },
         process: { target: 'IN_PROGRESS' },
         abort: { target: 'ABORTED' },
         pause: { target: 'PAUSED' },
@@ -54,20 +50,12 @@ const jobStateMachine = setup({
         fail: { target: 'FAILED' },
         abort: { target: 'ABORTED' },
         pause: { target: 'PAUSED' },
-        wait: { target: 'WAITING' },
       },
     },
     PAUSED: {
       on: {
         pend: { target: 'PENDING' },
-        wait: { target: 'WAITING' },
         process: { target: 'IN_PROGRESS' },
-        abort: { target: 'ABORTED' },
-      },
-    },
-    WAITING: {
-      on: {
-        pend: { target: 'PENDING' },
         abort: { target: 'ABORTED' },
       },
     },

--- a/src/openapi.d.ts
+++ b/src/openapi.d.ts
@@ -598,7 +598,7 @@ export type components = {
      * @example CREATED
      * @enum {string}
      */
-    jobOperationStatus: 'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED' | 'ABORTED' | 'PAUSED' | 'WAITING' | 'CREATED';
+    jobOperationStatus: 'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED' | 'ABORTED' | 'PAUSED' | 'CREATED';
     /**
      * @description Execution state of a stage within a job's workflow, tracking progress through its lifecycle.
      *     Finite states from which no further transitions are possible include: COMPLETED, FAILED, and ABORTED.


### PR DESCRIPTION
Eliminate the WAITING status from the job operation status enum and related components to streamline the job status management. This change updates the database and related code to reflect the removal.