### PR TITLE
refactor: remove PAUSED status from stage operation status enum and related components (MAPCO-7901)

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -1157,7 +1157,6 @@ components:
         - COMPLETED
         - FAILED
         - ABORTED
-        - PAUSED
         - WAITING
         - CREATED
       example: CREATED
@@ -1176,7 +1175,7 @@ components:
       example: CREATED
       description: |
         Current operational state of a task, including specialized states like RETRIED for task-specific error handling.
-        Finite states from which no further transitions are possible include: COMPLETED, FAILED, and ABORTED.
+        Finite states from which no further transitions are possible include: COMPLETED and FAILED.
     jobName:
       type: string
       enum:

--- a/src/db/prisma/migrations/20250702104402_remove_paused_statuses_stage/migration.sql
+++ b/src/db/prisma/migrations/20250702104402_remove_paused_statuses_stage/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - The values [Paused] on the enum `stage_operation_status_enum` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "stage_operation_status_enum_new" AS ENUM ('Pending', 'In-Progress', 'Completed', 'Failed', 'Aborted', 'Waiting', 'Created');
+ALTER TABLE "stage" ALTER COLUMN "status" DROP DEFAULT;
+ALTER TABLE "stage" ALTER COLUMN "status" TYPE "stage_operation_status_enum_new" USING ("status"::text::"stage_operation_status_enum_new");
+ALTER TYPE "stage_operation_status_enum" RENAME TO "stage_operation_status_enum_old";
+ALTER TYPE "stage_operation_status_enum_new" RENAME TO "stage_operation_status_enum";
+DROP TYPE "stage_operation_status_enum_old";
+ALTER TABLE "stage" ALTER COLUMN "status" SET DEFAULT 'Created';
+COMMIT;

--- a/src/db/prisma/schema.prisma
+++ b/src/db/prisma/schema.prisma
@@ -49,7 +49,6 @@ enum StageOperationStatus {
   COMPLETED   @map("Completed")
   FAILED      @map("Failed")
   ABORTED     @map("Aborted")
-  PAUSED      @map("Paused")
   WAITING     @map("Waiting")
   CREATED     @map("Created")
 

--- a/src/openapi.d.ts
+++ b/src/openapi.d.ts
@@ -606,10 +606,10 @@ export type components = {
      * @example CREATED
      * @enum {string}
      */
-    stageOperationStatus: 'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED' | 'ABORTED' | 'PAUSED' | 'WAITING' | 'CREATED';
+    stageOperationStatus: 'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED' | 'ABORTED' | 'WAITING' | 'CREATED';
     /**
      * @description Current operational state of a task, including specialized states like RETRIED for task-specific error handling.
-     *     Finite states from which no further transitions are possible include: COMPLETED, FAILED, and ABORTED.
+     *     Finite states from which no further transitions are possible include: COMPLETED and FAILED.
      *
      * @example CREATED
      * @enum {string}

--- a/src/stages/models/stageStateMachine.ts
+++ b/src/stages/models/stageStateMachine.ts
@@ -2,7 +2,7 @@
 import { setup } from 'xstate';
 import { StageOperationStatus } from '@prismaClient';
 
-type changeStatusOperations = 'pend' | 'wait' | 'pause' | 'abort' | 'complete' | 'process' | 'fail' | 'create';
+type changeStatusOperations = 'pend' | 'wait' | 'abort' | 'complete' | 'process' | 'fail' | 'create';
 
 const OperationStatusMapper: { [key in StageOperationStatus]: changeStatusOperations } = {
   [StageOperationStatus.PENDING]: 'pend',
@@ -12,7 +12,6 @@ const OperationStatusMapper: { [key in StageOperationStatus]: changeStatusOperat
   [StageOperationStatus.ABORTED]: 'abort',
   [StageOperationStatus.WAITING]: 'wait',
   [StageOperationStatus.CREATED]: 'create',
-  [StageOperationStatus.PAUSED]: 'pause',
 };
 
 const stageStateMachine = setup({
@@ -20,7 +19,6 @@ const stageStateMachine = setup({
     events: {} as
       | { type: 'pend' }
       | { type: 'wait' }
-      | { type: 'pause' }
       | { type: 'abort' }
       | { type: 'complete' }
       | { type: 'process' }
@@ -35,7 +33,6 @@ const stageStateMachine = setup({
       on: {
         pend: { target: 'PENDING' },
         wait: { target: 'WAITING' },
-        pause: { target: 'PAUSED' },
         abort: { target: 'ABORTED' },
       },
     },
@@ -44,7 +41,6 @@ const stageStateMachine = setup({
         wait: { target: 'WAITING' },
         process: { target: 'IN_PROGRESS' },
         abort: { target: 'ABORTED' },
-        pause: { target: 'PAUSED' },
       },
     },
     IN_PROGRESS: {
@@ -52,16 +48,7 @@ const stageStateMachine = setup({
         complete: { target: 'COMPLETED' },
         fail: { target: 'FAILED' },
         abort: { target: 'ABORTED' },
-        pause: { target: 'PAUSED' },
         wait: { target: 'WAITING' },
-      },
-    },
-    PAUSED: {
-      on: {
-        pend: { target: 'PENDING' },
-        wait: { target: 'WAITING' },
-        process: { target: 'IN_PROGRESS' },
-        abort: { target: 'ABORTED' },
       },
     },
     WAITING: {

--- a/tests/integration/stages/stages.spec.ts
+++ b/tests/integration/stages/stages.spec.ts
@@ -16,7 +16,7 @@ import { errorMessages as stagesErrorMessages } from '@src/stages/models/errors'
 import { errorMessages as commonErrorMessages } from '@src/common/errors';
 import { TaskCreateModel } from '@src/tasks/models/models';
 import { defaultStatusCounts } from '@src/stages/models/helper';
-import { abortedStageXstatePersistentSnapshot, pendingStageXstatePersistentSnapshot } from '@tests/unit/data';
+import { pendingStageXstatePersistentSnapshot } from '@tests/unit/data';
 import { createJobRecord, createJobRequestBody, createJobRequestWithStagesBody, testJobId, testStageId } from '../jobs/helpers';
 import { createTaskBody, createTaskRecords } from '../tasks/helpers';
 import { addJobRecord, addStageRecord, createStageWithJob, createStageWithoutTaskBody } from './helpers';
@@ -116,7 +116,7 @@ describe('stage', function () {
         );
 
         const tasks = await createTaskRecords(
-          [{ ...createTaskBody, stageId: stage.id, status: TaskOperationStatus.PENDING, xstate: abortedStageXstatePersistentSnapshot }],
+          [{ ...createTaskBody, stageId: stage.id, status: TaskOperationStatus.PENDING, xstate: pendingStageXstatePersistentSnapshot }],
           prisma
         );
 


### PR DESCRIPTION
Eliminate the PAUSED status from the stage operation status enum and related components to streamline the operational states. Update the database schema accordingly to reflect this change.