### PR TITLE
refactor: rename tillDate to endDate in API parameters and models

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -13,7 +13,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/jobNameQueryParam'
         - $ref: '#/components/parameters/fromDate'
-        - $ref: '#/components/parameters/tillDate'
+        - $ref: '#/components/parameters/endDate'
         - $ref: '#/components/parameters/priority'
         - $ref: '#/components/parameters/includeStages'
       summary: Retrieve jobs matching specified criteria
@@ -737,7 +737,7 @@ paths:
       - $ref: '#/components/parameters/paramStageId'
       - $ref: '#/components/parameters/paramTaskType'
       - $ref: '#/components/parameters/fromDate'
-      - $ref: '#/components/parameters/tillDate'
+      - $ref: '#/components/parameters/endDate'
       - $ref: '#/components/parameters/paramsTaskStatus'
     get:
       operationId: getTasksByCriteria
@@ -1019,9 +1019,9 @@ components:
       schema:
         type: string
         format: date-time
-    tillDate:
+    endDate:
       in: query
-      name: till_date
+      name: end_date
       description: Filter results by update time, ending at this date/time
       required: false
       schema:

--- a/src/jobs/models/manager.ts
+++ b/src/jobs/models/manager.ts
@@ -27,7 +27,7 @@ export class JobManager {
           AND: {
             name: { equals: params.job_name },
             priority: { equals: params.priority },
-            creationTime: { gte: params.from_date, lte: params.till_date },
+            creationTime: { gte: params.from_date, lte: params.end_date },
           },
         },
         include: { stage: params.should_return_stages },

--- a/src/openapi.d.ts
+++ b/src/openapi.d.ts
@@ -401,7 +401,7 @@ export type paths = {
         /** @description Filter results by update time, starting from this date/time */
         from_date?: components['parameters']['fromDate'];
         /** @description Filter results by update time, ending at this date/time */
-        till_date?: components['parameters']['tillDate'];
+        end_date?: components['parameters']['endDate'];
         /** @description Filter tasks by their operational status */
         status?: components['parameters']['paramsTaskStatus'];
       };
@@ -807,7 +807,7 @@ export type components = {
     /** @description Filter results by update time, starting from this date/time */
     fromDate: string;
     /** @description Filter results by update time, ending at this date/time */
-    tillDate: string;
+    endDate: string;
     /** @description When true, includes stage data in the response */
     includeStages: components['schemas']['returnStage'];
     /** @description When true, includes task data in the response */
@@ -841,7 +841,7 @@ export interface operations {
         /** @description Filter results by update time, starting from this date/time */
         from_date?: components['parameters']['fromDate'];
         /** @description Filter results by update time, ending at this date/time */
-        till_date?: components['parameters']['tillDate'];
+        end_date?: components['parameters']['endDate'];
         /** @description Filter jobs by their priority level */
         priority?: components['parameters']['priority'];
         /** @description When true, includes stage data in the response */
@@ -1687,7 +1687,7 @@ export interface operations {
         /** @description Filter results by update time, starting from this date/time */
         from_date?: components['parameters']['fromDate'];
         /** @description Filter results by update time, ending at this date/time */
-        till_date?: components['parameters']['tillDate'];
+        end_date?: components['parameters']['endDate'];
         /** @description Filter tasks by their operational status */
         status?: components['parameters']['paramsTaskStatus'];
       };

--- a/src/tasks/models/manager.ts
+++ b/src/tasks/models/manager.ts
@@ -144,7 +144,7 @@ export class TaskManager {
             stageId: { equals: params.stage_id },
             type: { equals: params.task_type },
             status: { equals: params.status },
-            creationTime: { gte: params.from_date, lte: params.till_date },
+            creationTime: { gte: params.from_date, lte: params.end_date },
           },
         },
       };


### PR DESCRIPTION
Update API parameters and models to replace `tillDate` with `endDate` for clarity and consistency.