### PR TITLE
refactor: change job name type from enum to string and update related migration (MAPCO-7900)

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -1167,11 +1167,8 @@ components:
         Finite states from which no further transitions are possible include: COMPLETED and FAILED.
     jobName:
       type: string
-      enum:
-        - INGESTION
-        - EXPORT
-        - DEFAULT
       example: DEFAULT
+      maxLength: 50
       description: Category or type of job processing being performed, used for filtering and system behaviors
     stageType:
       type: string

--- a/src/db/prisma/migrations/20250720081002_job_name_to_free_form/migration.sql
+++ b/src/db/prisma/migrations/20250720081002_job_name_to_free_form/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - The `name` column on the `job` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- AlterTable
+ALTER TABLE "job" DROP COLUMN "name",
+ADD COLUMN     "name" TEXT NOT NULL DEFAULT 'DEFAULT';
+
+-- DropEnum
+DROP TYPE "job_name_enum";

--- a/src/db/prisma/schema.prisma
+++ b/src/db/prisma/schema.prisma
@@ -26,7 +26,7 @@ model Job {
   updateTime   DateTime           @updatedAt @map("update_time")
   userMetadata Json               @default("{}") @map("user_metadata")
   priority     Priority           @default(VERY_LOW)
-  name         JobName            @default(DEFAULT)
+  name         String             @default("DEFAULT")
   stage        Stage[]
 
   @@map("job")
@@ -64,14 +64,6 @@ enum Priority {
   VERY_LOW  @map("Very-Low")
 
   @@map("priority_enum")
-}
-
-enum JobName {
-  INGESTION @map("Ingestion")
-  EXPORT    @map("Export")
-  DEFAULT   @map("Default")
-
-  @@map("job_name_enum")
 }
 
 model Stage {

--- a/src/openapi.d.ts
+++ b/src/openapi.d.ts
@@ -615,9 +615,8 @@ export type components = {
     /**
      * @description Category or type of job processing being performed, used for filtering and system behaviors
      * @example DEFAULT
-     * @enum {string}
      */
-    jobName: 'INGESTION' | 'EXPORT' | 'DEFAULT';
+    jobName: string;
     /**
      * @description Free-form string identifier for stage functionality, allowing flexible categorization
      *     of stage operations. Used for routing tasks to appropriate workers and
@@ -982,6 +981,9 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
+          /** @example {
+           *       "code": "JOB_DELETED_SUCCESSFULLY"
+           *     } */
           'application/json': components['schemas']['defaultOkMessage'];
         };
       };
@@ -1036,6 +1038,9 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
+          /** @example {
+           *       "code": "JOB_MODIFIED_SUCCESSFULLY"
+           *     } */
           'application/json': components['schemas']['defaultOkMessage'];
         };
       };
@@ -1092,6 +1097,9 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
+          /** @example {
+           *       "code": "JOB_MODIFIED_SUCCESSFULLY"
+           *     } */
           'application/json': components['schemas']['defaultOkMessage'];
         };
       };
@@ -1157,6 +1165,9 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
+          /** @example {
+           *       "code": "JOB_MODIFIED_SUCCESSFULLY"
+           *     } */
           'application/json': components['schemas']['defaultOkMessage'];
         };
       };
@@ -1470,6 +1481,9 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
+          /** @example {
+           *       "code": "STAGE_MODIFIED_SUCCESSFULLY"
+           *     } */
           'application/json': components['schemas']['defaultOkMessage'];
         };
       };
@@ -1526,6 +1540,9 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
+          /** @example {
+           *       "code": "STAGE_MODIFIED_SUCCESSFULLY"
+           *     } */
           'application/json': components['schemas']['defaultOkMessage'];
         };
       };
@@ -1842,6 +1859,9 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
+          /** @example {
+           *       "code": "TASK_MODIFIED_SUCCESSFULLY"
+           *     } */
           'application/json': components['schemas']['defaultOkMessage'];
         };
       };

--- a/tests/integration/jobs/helpers.ts
+++ b/tests/integration/jobs/helpers.ts
@@ -1,6 +1,6 @@
 import { createActor } from 'xstate';
 import { faker } from '@faker-js/faker';
-import { JobName, type Prisma, type PrismaClient } from '@prismaClient';
+import { type Prisma, type PrismaClient } from '@prismaClient';
 import { jobStateMachine } from '@src/jobs/models/jobStateMachine';
 import { JobCreateModel, JobPrismaObject } from '@src/jobs/models/models';
 
@@ -16,7 +16,7 @@ export const createJobRecord = async (body: JobTestCreateModel, prisma: PrismaCl
 };
 
 export const createJobRequestBody = {
-  name: JobName.DEFAULT,
+  name: 'DEFAULT',
   data: {},
   userMetadata: {},
 } satisfies JobCreateModel;

--- a/tests/integration/jobs/jobs.spec.ts
+++ b/tests/integration/jobs/jobs.spec.ts
@@ -6,7 +6,7 @@ import { createRequestSender, RequestSender } from '@map-colonies/openapi-helper
 import type { MatcherContext } from '@jest/expect';
 import { faker } from '@faker-js/faker';
 import type { paths, operations } from '@openapi';
-import { JobName, JobOperationStatus, Priority, StageOperationStatus, type PrismaClient } from '@prismaClient';
+import { JobOperationStatus, Priority, StageOperationStatus, type PrismaClient } from '@prismaClient';
 import { getApp } from '@src/app';
 import { SERVICES, successMessages } from '@common/constants';
 import { initConfig } from '@src/common/config';
@@ -162,7 +162,7 @@ describe('job', function () {
     describe('Bad Path', function () {
       it('should return a 400 status code along with a specific validation error message detailing the missing required parameters for job creation', async function () {
         const badRequestBody = {
-          name: JobName.DEFAULT,
+          name: 'DEFAULT',
         } as unknown as JobCreateModel;
 
         const response = await requestSender.createJob({

--- a/tests/unit/generator.ts
+++ b/tests/unit/generator.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { createActor } from 'xstate';
-import { JobName, JobOperationStatus, Priority, Prisma, Stage, StageOperationStatus, Task, TaskOperationStatus } from '@prismaClient';
+import { JobOperationStatus, Priority, Prisma, Stage, StageOperationStatus, Task, TaskOperationStatus } from '@prismaClient';
 import { jobStateMachine } from '@src/jobs/models/jobStateMachine';
 import { JobCreateModel } from '@src/jobs/models/models';
 import { stageStateMachine } from '@src/stages/models/stageStateMachine';
@@ -20,7 +20,7 @@ export interface StageWithTasks extends Prisma.StageGetPayload<Record<string, un
 }
 
 export const createJobParams = {
-  name: JobName.DEFAULT,
+  name: 'DEFAULT',
   data: { stages: [] },
   userMetadata: {},
 } satisfies JobCreateModel;
@@ -30,7 +30,7 @@ export function createJobEntity(override: Partial<JobWithStages>): JobWithStages
     creationTime: new Date(),
     data: {},
     id: randomUuid,
-    name: JobName.DEFAULT,
+    name: 'DEFAULT',
     percentage: 0,
     priority: Priority.HIGH,
     status: JobOperationStatus.PENDING,


### PR DESCRIPTION
Change the job name type from an enum to a string to allow for greater flexibility and update the related database migration accordingly. This change also includes adjustments in the model and various components to reflect the new type.