### PR TITLE
refactor: simplify query parameter handling in getJobById and getStagesByJobId

### DIFF
--- a/src/jobs/controllers/jobController.ts
+++ b/src/jobs/controllers/jobController.ts
@@ -43,11 +43,7 @@ export class JobController {
 
   public getJobById: TypedRequestHandlers['GET /jobs/{jobId}'] = async (req, res, next) => {
     try {
-      let includeStages: boolean | undefined = false;
-
-      if (req.query) {
-        includeStages = req.query.should_return_stages;
-      }
+      const includeStages: boolean | undefined = req.query?.should_return_stages ?? false;
 
       const response = await this.manager.getJobById(req.params.jobId, includeStages);
 

--- a/src/stages/controllers/stageController.ts
+++ b/src/stages/controllers/stageController.ts
@@ -43,11 +43,7 @@ export class StageController {
 
   public getStagesByJobId: TypedRequestHandlers['GET /jobs/{jobId}/stages'] = async (req, res, next) => {
     try {
-      let includeTasks: boolean | undefined = false;
-
-      if (req.query) {
-        includeTasks = req.query.should_return_tasks;
-      }
+      const includeTasks: boolean | undefined = req.query?.should_return_tasks ?? false;
 
       const response = await this.manager.getStagesByJobId(req.params.jobId, includeTasks);
       return res.status(httpStatus.OK).json(response);

--- a/tests/unit/jobs/jobs.spec.ts
+++ b/tests/unit/jobs/jobs.spec.ts
@@ -68,6 +68,18 @@ describe('JobManager', () => {
 
           expect(jobs).toMatchObject(expectedJob);
         });
+
+        it('should return all formatted jobs when no criteria is provided', async function () {
+          const jobEntity = { ...jobEntityWithoutStages };
+          jest.spyOn(prisma.job, 'findMany').mockResolvedValue([jobEntity]);
+
+          const jobs = await jobManager.getJobs(undefined);
+
+          const { xstate, stage, ...rest } = jobEntity;
+          const expectedJob = [{ ...rest, stages: stage, creationTime: rest.creationTime.toISOString(), updateTime: rest.updateTime.toISOString() }];
+
+          expect(jobs).toMatchObject(expectedJob);
+        });
       });
 
       describe('#SadPath', () => {

--- a/tests/unit/stages/stages.spec.ts
+++ b/tests/unit/stages/stages.spec.ts
@@ -66,6 +66,18 @@ describe('JobManager', () => {
           expect(stages).toMatchObject(expectedStage);
           expect(stages[0]?.tasks).toMatchObject([{ id: taskEntity.id }]);
         });
+
+        it('should return array with all stages when no criteria is provided', async function () {
+          const stageEntity = createStageEntity({});
+          jest.spyOn(prisma.stage, 'findMany').mockResolvedValue([stageEntity]);
+
+          const stages = await stageManager.getStages(undefined);
+          const { xstate, task, ...rest } = stageEntity;
+
+          const expectedStage = [rest];
+
+          expect(stages).toMatchObject(expectedStage);
+        });
       });
 
       describe('#SadPath', () => {


### PR DESCRIPTION
Simplify the handling of query parameters in `getJobById` and `getStagesByJobId` methods for improved readability and maintainability.