### PR TITLE
ci: update node version matrix to include 24.x

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [20.x, 22.x]
+        node: [22.x, 24.x]
 
     steps:
       - name: Check out TS Project Git repository
@@ -52,7 +52,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [20.x, 22.x]
+        node: [22.x, 24.x]
 
     services:
       # Label used to access the service container


### PR DESCRIPTION
Expand the Node.js version matrix in the CI configuration to support version 24.x alongside 22.x.