### PR TITLE
ci: add jira integration MAPCO-8356

### DIFF
--- a/.github/workflows/jira-integration.yaml
+++ b/.github/workflows/jira-integration.yaml
@@ -1,0 +1,14 @@
+name: Jira Integration
+on:
+  pull_request:
+    types: [opened, edited]
+
+permissions:
+  statuses: write
+  pull-requests: write
+
+jobs:
+  jira-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mapcolonies/javascript-github-actions/actions/jira-integration@jira-integration-v1.0.1


### PR DESCRIPTION
Implement a GitHub Action to validate pull requests with Jira integration, enhancing project management and tracking.