### PR TITLE
deps: update eslint-plugin-jest to version 29.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "copyfiles": "^2.4.1",
         "cross-env": "^7.0.3",
         "eslint": "^9.33.0",
-        "eslint-plugin-jest": "^28.11.0",
+        "eslint-plugin-jest": "^29.0.1",
         "husky": "^9.1.7",
         "jest": "^30.0.5",
         "jest-create-mock-instance": "^2.0.0",
@@ -8680,20 +8680,20 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.14.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.14.0.tgz",
-      "integrity": "sha512-P9s/qXSMTpRTerE2FQ0qJet2gKbcGyFTPAJipoKxmWqR6uuFqIqk8FuEfg5yBieOezVrEfAMZrEwJ6yEp+1MFQ==",
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.0.1.tgz",
+      "integrity": "sha512-EE44T0OSMCeXhDrrdsbKAhprobKkPtJTbQz5yEktysNpHeDZTAL1SfDTNKmcFfJkY6yrQLtTKZALrD3j/Gpmiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "@typescript-eslint/utils": "^8.0.0"
       },
       "engines": {
-        "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
+        "node": "^20.12.0 || ^22.0.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^6.0.0 || ^7.0.0 || ^8.0.0",
-        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0",
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0",
         "jest": "*"
       },
       "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "copyfiles": "^2.4.1",
     "cross-env": "^7.0.3",
     "eslint": "^9.33.0",
-    "eslint-plugin-jest": "^28.11.0",
+    "eslint-plugin-jest": "^29.0.1",
     "husky": "^9.1.7",
     "jest": "^30.0.5",
     "jest-create-mock-instance": "^2.0.0",


### PR DESCRIPTION
Upgrade eslint-plugin-jest to the latest version to ensure compatibility and access to new features and improvements.