### PR TITLE
helm: add Prometheus annotations for service metrics

### DIFF
--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -12,6 +12,10 @@ metadata:
     environment: {{ include "jobnik-manager.environment" . }}
     release: {{ $releaseName }}
     {{- include "jobnik-manager.labels" . | nindent 4 }}
+  annotations:
+    prometheus.io/path: /service-metrics
+    prometheus.io/port: {{ .Values.env.port | quote }}
+    prometheus.io/scrape: {{ .Values.mclabels.prometheus.enabled }}
 spec:
   {{- if eq $cloudProviderFlavor "minikube" }}
   type: NodePort


### PR DESCRIPTION
Include annotations for Prometheus to scrape service metrics, specifying the path, port, and scrape enablement based on values.