### PR TITLE
style: add .release-please-manifest.json to prettier ignore list

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ node_modules
 coverage
 helm
 reports
+.release-please-manifest.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "include-component-in-tag": false,
+  "initial-version": "0.1.0",
   "packages": {
     ".": {
       "extra-files": [


### PR DESCRIPTION
Ignore the .release-please-manifest.json file in Prettier formatting and set the initial version to 0.1.0 in the manifest.