### PR TITLE
build: upgrade Node.js version to 24 in Dockerfile MAPCO-9125

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24 as build
+FROM node:24 AS build
 
 
 WORKDIR /tmp/buildApp
@@ -10,7 +10,7 @@ RUN npm install
 COPY . .
 RUN npm run build
 
-FROM node:24-alpine as production
+FROM node:24-alpine AS production
 
 RUN apk add --no-cache dumb-init openssl
 


### PR DESCRIPTION
Upgrade the Node.js version in the Dockerfile to 24 and include necessary peer dependencies in the package-lock.json.