### PR TITLE
refactor: replace MatcherContext with string in validation error messages MAPCO-9051

### DIFF
--- a/tests/integration/jobs/jobs.spec.ts
+++ b/tests/integration/jobs/jobs.spec.ts
@@ -5,7 +5,6 @@ import { InMemorySpanExporter, NodeTracerProvider, SimpleSpanProcessor } from '@
 import { trace } from '@opentelemetry/api';
 import { StatusCodes } from 'http-status-codes';
 import { createRequestSender, RequestSender } from '@map-colonies/openapi-helpers/requestSender';
-import type { MatcherContext } from '@jest/expect';
 import type { paths, operations } from '@openapi';
 import { JobOperationStatus, Priority, StageOperationStatus, type PrismaClient } from '@prismaClient';
 import { getApp } from '@src/app';
@@ -123,7 +122,7 @@ describe('job', function () {
         expect(response).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
           body: {
-            message: expect.stringMatching(/request\/query\/priority must be equal to one of the allowed values/) as MatcherContext,
+            message: expect.stringMatching(/request\/query\/priority must be equal to one of the allowed values/) as string,
             code: 'VALIDATION_ERROR',
           },
         });
@@ -135,7 +134,7 @@ describe('job', function () {
         expect(response).toSatisfyApiSpec();
         expect(response).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
-          body: { message: expect.stringMatching(/Unknown query parameter/) as MatcherContext, code: 'VALIDATION_ERROR' },
+          body: { message: expect.stringMatching(/Unknown query parameter/) as string, code: 'VALIDATION_ERROR' },
         });
       });
     });
@@ -246,7 +245,7 @@ describe('job', function () {
         expect(response).toSatisfyApiSpec();
         expect(response).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
-          body: { message: expect.stringMatching(/request\/body must have required property/) as MatcherContext, code: 'VALIDATION_ERROR' },
+          body: { message: expect.stringMatching(/request\/body must have required property/) as string, code: 'VALIDATION_ERROR' },
         });
       });
 
@@ -258,7 +257,7 @@ describe('job', function () {
         expect(createJobResponse).toSatisfyApiSpec();
         expect(createJobResponse).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
-          body: { message: expect.stringMatching(/request\/body\/traceparent must match pattern/) as MatcherContext, code: 'VALIDATION_ERROR' },
+          body: { message: expect.stringMatching(/request\/body\/traceparent must match pattern/) as string, code: 'VALIDATION_ERROR' },
         });
       });
 
@@ -271,7 +270,7 @@ describe('job', function () {
         expect(createJobResponse).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
           body: {
-            message: expect.stringMatching(/request\/body\/name must NOT have fewer than 2 characters/) as MatcherContext,
+            message: expect.stringMatching(/request\/body\/name must NOT have fewer than 2 characters/) as string,
             code: 'VALIDATION_ERROR',
           },
         });
@@ -285,7 +284,7 @@ describe('job', function () {
         expect(createJobResponse).toSatisfyApiSpec();
         expect(createJobResponse).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
-          body: { message: expect.stringMatching(/request\/body must NOT have additional properties/) as MatcherContext, code: 'VALIDATION_ERROR' },
+          body: { message: expect.stringMatching(/request\/body must NOT have additional properties/) as string, code: 'VALIDATION_ERROR' },
         });
       });
     });
@@ -382,7 +381,7 @@ describe('job', function () {
         expect(getJobResponse).toSatisfyApiSpec();
         expect(getJobResponse).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
-          body: { message: expect.stringMatching(/request\/params\/jobId must match format "uuid"/) as MatcherContext, code: 'VALIDATION_ERROR' },
+          body: { message: expect.stringMatching(/request\/params\/jobId must match format "uuid"/) as string, code: 'VALIDATION_ERROR' },
         });
       });
     });
@@ -556,7 +555,7 @@ describe('job', function () {
         expect(getJobResponse).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
           body: {
-            message: expect.stringMatching(/request\/body\/priority must be equal to one of the allowed values:/) as MatcherContext,
+            message: expect.stringMatching(/request\/body\/priority must be equal to one of the allowed values:/) as string,
             code: 'VALIDATION_ERROR',
           },
         });
@@ -657,7 +656,7 @@ describe('job', function () {
         expect(setStatusResponse).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
           body: {
-            message: expect.stringMatching(/request\/body\/status must be equal to one of the allowed values/) as MatcherContext,
+            message: expect.stringMatching(/request\/body\/status must be equal to one of the allowed values/) as string,
             code: 'VALIDATION_ERROR',
           },
         });
@@ -684,7 +683,7 @@ describe('job', function () {
         expect(getJobResponse).toSatisfyApiSpec();
         expect(getJobResponse).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
-          body: { message: expect.stringMatching(/request\/params\/jobId must match format "uuid"/) as MatcherContext, code: 'VALIDATION_ERROR' },
+          body: { message: expect.stringMatching(/request\/params\/jobId must match format "uuid"/) as string, code: 'VALIDATION_ERROR' },
         });
       });
     });
@@ -767,7 +766,7 @@ describe('job', function () {
         expect(deleteJobResponse).toSatisfyApiSpec();
         expect(deleteJobResponse).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
-          body: { message: expect.stringMatching(/request\/params\/jobId must match format "uuid"/) as MatcherContext },
+          body: { message: expect.stringMatching(/request\/params\/jobId must match format "uuid"/) as string },
         });
       });
 

--- a/tests/integration/stages/stages.spec.ts
+++ b/tests/integration/stages/stages.spec.ts
@@ -6,7 +6,6 @@ import { StatusCodes } from 'http-status-codes';
 import { InMemorySpanExporter, NodeTracerProvider, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-node';
 import { createRequestSender, RequestSender } from '@map-colonies/openapi-helpers/requestSender';
 import { faker } from '@faker-js/faker';
-import type { MatcherContext } from '@jest/expect';
 import type { paths, operations } from '@openapi';
 import { JobOperationStatus, StageOperationStatus, TaskOperationStatus, type PrismaClient } from '@prismaClient';
 import { getApp } from '@src/app';
@@ -169,7 +168,7 @@ describe('stage', function () {
         expect(response).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
           body: {
-            message: expect.stringMatching(/request\/query\/stage_type must NOT have more than 50 characters/) as MatcherContext,
+            message: expect.stringMatching(/request\/query\/stage_type must NOT have more than 50 characters/) as string,
             code: 'VALIDATION_ERROR',
           },
         });
@@ -279,7 +278,7 @@ describe('stage', function () {
         expect(getStageResponse).toSatisfyApiSpec();
         expect(getStageResponse).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
-          body: { message: expect.stringMatching(/request\/params\/stageId must match format "uuid"/) as MatcherContext, code: 'VALIDATION_ERROR' },
+          body: { message: expect.stringMatching(/request\/params\/stageId must match format "uuid"/) as string, code: 'VALIDATION_ERROR' },
         });
       });
     });
@@ -433,7 +432,7 @@ describe('stage', function () {
         expect(getStageResponse).toSatisfyApiSpec();
         expect(getStageResponse).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
-          body: { message: expect.stringMatching(/request\/params\/jobId must match format "uuid"/) as MatcherContext, code: 'VALIDATION_ERROR' },
+          body: { message: expect.stringMatching(/request\/params\/jobId must match format "uuid"/) as string, code: 'VALIDATION_ERROR' },
         });
       });
 
@@ -506,7 +505,7 @@ describe('stage', function () {
         expect(getStageResponse).toSatisfyApiSpec();
         expect(getStageResponse).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
-          body: { message: expect.stringMatching(/request\/params\/stageId must match format "uuid"/) as MatcherContext, code: 'VALIDATION_ERROR' },
+          body: { message: expect.stringMatching(/request\/params\/stageId must match format "uuid"/) as string, code: 'VALIDATION_ERROR' },
         });
       });
     });
@@ -581,7 +580,7 @@ describe('stage', function () {
         expect(response).toSatisfyApiSpec();
         expect(response).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
-          body: { message: expect.stringMatching(/is not valid JSON/) as MatcherContext, code: 'VALIDATION_ERROR' },
+          body: { message: expect.stringMatching(/is not valid JSON/) as string, code: 'VALIDATION_ERROR' },
         });
       });
     });
@@ -1035,7 +1034,7 @@ describe('stage', function () {
         expect(addStageResponse).toSatisfyApiSpec();
         expect(addStageResponse).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
-          body: { message: expect.stringMatching(/request\/body\/traceparent must match pattern/) as MatcherContext, code: 'VALIDATION_ERROR' },
+          body: { message: expect.stringMatching(/request\/body\/traceparent must match pattern/) as string, code: 'VALIDATION_ERROR' },
         });
       });
 
@@ -1193,7 +1192,7 @@ describe('stage', function () {
         expect(updateStageResponse).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
           body: {
-            message: expect.stringMatching(/request\/body\/status must be equal to one of the allowed values/) as MatcherContext,
+            message: expect.stringMatching(/request\/body\/status must be equal to one of the allowed values/) as string,
             code: 'VALIDATION_ERROR',
           },
         });

--- a/tests/integration/tasks/tasks.spec.ts
+++ b/tests/integration/tasks/tasks.spec.ts
@@ -6,7 +6,6 @@ import { StatusCodes } from 'http-status-codes';
 import { InMemorySpanExporter, NodeTracerProvider, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-node';
 import { createRequestSender, RequestSender } from '@map-colonies/openapi-helpers/requestSender';
 import { faker } from '@faker-js/faker';
-import type { MatcherContext } from '@jest/expect';
 import type { paths, operations } from '@openapi';
 import { JobOperationStatus, Priority, Prisma, StageOperationStatus, TaskOperationStatus, type PrismaClient } from '@prismaClient';
 import { getApp } from '@src/app';
@@ -113,7 +112,7 @@ describe('task', function () {
         expect(response).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
           body: {
-            message: expect.stringMatching(/request\/query\/stage_type must NOT have more than 50 characters/) as MatcherContext,
+            message: expect.stringMatching(/request\/query\/stage_type must NOT have more than 50 characters/) as string,
             code: 'VALIDATION_ERROR',
           },
         });
@@ -125,7 +124,7 @@ describe('task', function () {
         expect(response).toSatisfyApiSpec();
         expect(response).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
-          body: { message: expect.stringMatching(/Unknown query parameter/) as MatcherContext, code: 'VALIDATION_ERROR' },
+          body: { message: expect.stringMatching(/Unknown query parameter/) as string, code: 'VALIDATION_ERROR' },
         });
       });
 
@@ -136,7 +135,7 @@ describe('task', function () {
         expect(response).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
           body: {
-            message: expect.stringMatching(/request\/query\/status must be equal to one of the allowed values/) as MatcherContext,
+            message: expect.stringMatching(/request\/query\/status must be equal to one of the allowed values/) as string,
             code: 'VALIDATION_ERROR',
           },
         });
@@ -202,7 +201,7 @@ describe('task', function () {
         expect(getTaskResponse).toSatisfyApiSpec();
         expect(getTaskResponse).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
-          body: { message: expect.stringMatching(/request\/params\/taskId must match format "uuid"/) as MatcherContext, code: 'VALIDATION_ERROR' },
+          body: { message: expect.stringMatching(/request\/params\/taskId must match format "uuid"/) as string, code: 'VALIDATION_ERROR' },
         });
       });
     });
@@ -276,7 +275,7 @@ describe('task', function () {
         expect(getTaskResponse).toSatisfyApiSpec();
         expect(getTaskResponse).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
-          body: { message: expect.stringMatching(/request\/params\/stageId must match format "uuid"/) as MatcherContext, code: 'VALIDATION_ERROR' },
+          body: { message: expect.stringMatching(/request\/params\/stageId must match format "uuid"/) as string, code: 'VALIDATION_ERROR' },
         });
       });
 
@@ -365,7 +364,7 @@ describe('task', function () {
         expect(response).toSatisfyApiSpec();
         expect(response).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
-          body: { message: expect.stringMatching('is not valid JSON') as MatcherContext, code: 'VALIDATION_ERROR' },
+          body: { message: expect.stringMatching('is not valid JSON') as string, code: 'VALIDATION_ERROR' },
         });
       });
     });
@@ -536,7 +535,7 @@ describe('task', function () {
 
         expect(addTasksResponse).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
-          body: { message: expect.stringMatching(/request\/params\/stageId must match format "uuid"/) as MatcherContext, code: 'VALIDATION_ERROR' },
+          body: { message: expect.stringMatching(/request\/params\/stageId must match format "uuid"/) as string, code: 'VALIDATION_ERROR' },
         });
       });
 
@@ -551,7 +550,7 @@ describe('task', function () {
 
         expect(addTasksResponse).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
-          body: { message: expect.stringMatching(/request\/body must be array/) as MatcherContext, code: 'VALIDATION_ERROR' },
+          body: { message: expect.stringMatching(/request\/body must be array/) as string, code: 'VALIDATION_ERROR' },
         });
       });
 
@@ -610,7 +609,7 @@ describe('task', function () {
 
         expect(createTaskResponse).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
-          body: { message: expect.stringMatching(/request\/body\/0\/traceparent must match pattern/) as MatcherContext, code: 'VALIDATION_ERROR' },
+          body: { message: expect.stringMatching(/request\/body\/0\/traceparent must match pattern/) as string, code: 'VALIDATION_ERROR' },
         });
       });
 
@@ -981,7 +980,7 @@ describe('task', function () {
         expect(updateStatusResponse).toSatisfyApiSpec();
         expect(updateStatusResponse).toMatchObject({
           status: StatusCodes.BAD_REQUEST,
-          body: { message: expect.stringMatching(/request\/params\/taskId must match format "uuid"/) as MatcherContext, code: 'VALIDATION_ERROR' },
+          body: { message: expect.stringMatching(/request\/params\/taskId must match format "uuid"/) as string, code: 'VALIDATION_ERROR' },
         });
       });
 


### PR DESCRIPTION
Replace `MatcherContext` with `string` in validation error messages to improve type consistency and clarity in error handling.