### PR TITLE
ci: add End-to-End tests job to pull request workflow MAPCO-8970

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -97,6 +97,9 @@ jobs:
     steps:
       - name: Run E2E tests
         uses: MapColonies/jobnik-e2e/.github/actions/e2e-tests@master
+        with:
+          manager_version: ${{ github.event.pull_request.head.sha }}
+
   build_docker_image:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Introduce a new job in the CI workflow to run End-to-End tests on pull requests.